### PR TITLE
[BUGFIX] Fix notices with PHP8

### DIFF
--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -141,7 +141,7 @@ class TcaService
                             ];
                         } else {
                             $cropVariantsTca[$cropVariantKey]['allowedAspectRatios']['NaN'] = [
-                                'title' => $dimensionConfig['title'] ?: 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
+                                'title' => $dimensionConfig['title'] ?? 'LLL:EXT:core/Resources/Private/Language/locallang_wizards.xlf:imwizard.ratio.free',
                                 'value' => .0,
                             ];
                         }


### PR DESCRIPTION
given the following configuration leads to an exception

```yaml
breakpoints:
    phone:
        to: 479
    tablet:
        from: 480
        to: 1023
    desktop:
        from: 1024

pixelDensities: [ 1, 2 ]

croppingConfiguration:
    tt_content:
        textmedia:
            assets:
                variants:
                    default:
                        sizes:
                            desktop:
                                breakpoints: desktop
                                width: 390
                                ratio: 'free'
```