### PR TITLE
[BUGIX] Properly pass through focus area and cover area

### DIFF
--- a/Classes/Service/TcaService.php
+++ b/Classes/Service/TcaService.php
@@ -101,11 +101,17 @@ class TcaService
             $identifier = $sizeConfig['ratio'] ?? $sizeIdentifier;
             if (!isset($sizeConfig['allowedRatios']) && (isset($sizeConfig['width']) || isset($sizeConfig['height']))) {
                 $ratioIdentifier = $sizeConfig['title'] ?? $sizeConfig['ratio'] ?? ($sizeConfig['width'] . ' x ' . $sizeConfig['height']);
-                $sizeConfig = [
-                    'allowedRatios' => [
-                        $ratioIdentifier => $sizeConfig,
-                    ],
-                ];
+                $nestedConfig = $sizeConfig;
+                $sizeConfig = [];
+                if (isset($nestedConfig['focusArea'])) {
+                    $sizeConfig['focusArea'] = $nestedConfig['focusArea'];
+                    unset($nestedConfig['focusArea']);
+                }
+                if (isset($nestedConfig['coverArea'])) {
+                    $sizeConfig['coverArea'] = $nestedConfig['coverArea'];
+                    unset($nestedConfig['coverArea']);
+                }
+                $sizeConfig['allowedRatios'][$ratioIdentifier] = $nestedConfig;
             }
             foreach ($sizeConfig['allowedRatios'] as $allowedRatioKey => $allowedRatioConfig) {
                 $dimensions = new Dimensions($allowedRatioConfig['width'] ?? null, $allowedRatioConfig['height'] ?? null, $allowedRatioConfig['ratio'] ?? null);


### PR DESCRIPTION
When only one ratio is defined,
the focus and cover area config is lost,
when transforming to allowedRatios config.